### PR TITLE
Fixes for handsontable 0.11.2

### DIFF
--- a/select2-editor.js
+++ b/select2-editor.js
@@ -42,7 +42,7 @@
 
         var that = this;
         Handsontable.PluginHooks.add('afterRender', function () {
-            that.instance.registerTimeout('refresh_editor_dimensions', function () {
+            that.instance._registerTimeout('refresh_editor_dimensions', function () {
                 that.refreshDimensions();
             }, 0);
         });
@@ -111,6 +111,7 @@
     
 
     Select2Editor.prototype.open = function () {
+		this.refreshDimensions();
         this.textareaParentStyle.display = 'block';
         this.instance.addHook('beforeKeyDown', onBeforeKeyDown);
 


### PR DESCRIPTION
A couple of fixes for making this work with handsontable 0.11.2
- renamed registerTimeout to _registerTimeout
- added refreshDimensions on open to avoid undefined element on close
```
Uncaught TypeError: Cannot read property 'removeEventListener' of undefined 
autoResize.unObserve()
TextEditor.prototype.close()
```