### PR TITLE
ngHandsontable support

### DIFF
--- a/select2-editor.js
+++ b/select2-editor.js
@@ -13,6 +13,10 @@
         if (cellProperties.select2Options) {
             this.options = $.extend(this.options, cellProperties.select2Options);
         }
+        // Also handle lowercase property (which may be used involuntary due to angular magic, for instance by using ngHandsontable)
+        if (cellProperties.select2options) {
+            this.options = $.extend(this.options, cellProperties.select2options);
+        }
     };
 
     Select2Editor.prototype.createElements = function () {

--- a/select2-editor.js
+++ b/select2-editor.js
@@ -10,7 +10,7 @@
 
         this.options = {};
 
-        if (this.cellProperties.select2Options) {
+        if (cellProperties.select2Options) {
             this.options = $.extend(this.options, cellProperties.select2Options);
         }
     };


### PR DESCRIPTION
After https://github.com/handsontable/ngHandsontable/pull/94 is merged, this PR makes it possible to set select2options via the hot-column directive and thus ability to use select2-editor in handsontable with angularjs